### PR TITLE
Loose lenses and remove duplicated instance

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -41,7 +41,7 @@ library
                , either >= 4 && < 4.5
                , exceptions >= 0.5 && < 0.9
                , hostname >=1.0 && <1.1
-               , lens >= 4.4 && <4.13
+               , lens >= 4.4 && <4.14
                , lens-aeson < 1.1
                , old-locale >= 1.0 && < 1.1
                , string-conv >= 0.1 && < 0.2

--- a/katip/test/Katip/Tests.hs
+++ b/katip/test/Katip/Tests.hs
@@ -69,7 +69,6 @@ deriving instance Arbitrary Namespace
 deriving instance Arbitrary Environment
 deriving instance Arbitrary ThreadIdText
 deriving instance Arbitrary CPid
-deriving instance Eq Loc
 deriving instance Eq LogStr
 deriving instance (Eq a) => Eq (Item a)
 


### PR DESCRIPTION
@MichaelXavier  @mightybyte @ozataman Could you take a look please? I needed to loose the lenses constraint so it would be the same as hadron. I also deleted a duplicated instance in the tests. However, I'm not sure if it's only because I'm using GHC 7.10.3.

