### PR TITLE
Move ToJSON to default signature in ToObject class

### DIFF
--- a/katip-elasticsearch/src/Katip/Scribes/ElasticSearch/Annotations.hs
+++ b/katip-elasticsearch/src/Katip/Scribes/ElasticSearch/Annotations.hs
@@ -31,7 +31,8 @@ instance ToJSON a => ToJSON (TypeAnnotated a) where
   toJSON = annotateValue . toJSON . typeAnnotatedValue
 
 
-instance ToObject a => ToObject (TypeAnnotated a)
+instance ToObject a => ToObject (TypeAnnotated a) where
+  toObject = annotateKeys . toObject . typeAnnotatedValue
 
 
 instance FromJSON a => FromJSON (TypeAnnotated a) where

--- a/katip-elasticsearch/test/Main.hs
+++ b/katip-elasticsearch/test/Main.hs
@@ -163,12 +163,18 @@ instance LogItem ExampleCtx where
 typeAnnotatedTests :: TestTree
 typeAnnotatedTests = testGroup "TypeAnnotated"
   [
-    testCase "annotates values on toJSON" $ do
+    testCase "annotates values on toJSON" $
       toJSON (TypeAnnotated exampleValue) @?= annotatedExampleValue
-  , testCase "deannotates on parseJSON" $ do
+
+  , testCase "annotates values on toObject" $
+      toObject (TypeAnnotated exampleObject) @?= annotatedExampleObject
+
+  , testCase "deannotates on parseJSON" $
       parseEither parseJSON (toJSON exampleValue) @?= Right exampleValue
+
   , testProperty "roundtrips the same as raw" $ \(v :: Value) ->
-      let res = typeAnnotatedValue <$> (parseEither parseJSON (toJSON (TypeAnnotated v)))
+      let res = typeAnnotatedValue
+                <$> parseEither parseJSON (toJSON (TypeAnnotated v))
       in res === Right v
   ]
 
@@ -187,33 +193,41 @@ roundToSundayTests = testGroup "roundToSunday"
   where
     getDOW = view _3 . toWeekDate
 
+
+-------------------------------------------------------------------------------
+exampleObject :: Object
+exampleObject = HM.fromList
+  [ ("a bool", Bool False)
+  , ("a long", Number 24)
+  , ("a double", Number 52.3)
+  , ("a string", String "s")
+  , ("a null", Null)
+  , ("a map", Object (HM.singleton "baz" (Bool True)))
+  ]
+
+
+-------------------------------------------------------------------------------
+annotatedExampleObject :: Object
+annotatedExampleObject = HM.fromList
+  [ ("a map",Object $ HM.fromList [("baz::b", Bool True)])
+  , ("a bool::b", Bool False)
+  , ("a null::n", Null)
+  , ("a string::s", String "s")
+  , ("a double::d", Number 52.3)
+  , ("a long::l", Number 24.0)
+  ]
+
+
 -------------------------------------------------------------------------------
 exampleValue :: Value
-exampleValue = Array $ V.fromList [Null, Object ob]
-  where
-    ob = HM.fromList [ ("a bool", Bool False)
-                     , ("a long", Number 24)
-                     , ("a double", Number 52.3)
-                     , ("a string", String "s")
-                     , ("a null", Null)
-                     , ("a map", Object (HM.singleton "baz" (Bool True)))
-                     ]
+exampleValue = Array $ V.fromList [Null, Object exampleObject]
 
 
 -------------------------------------------------------------------------------
 annotatedExampleValue :: Value
 annotatedExampleValue = Array $ V.fromList
-  [
-    Null
-  , Object $ HM.fromList
-    [
-      ("a map",Object $ HM.fromList [("baz::b", Bool True)])
-    , ("a bool::b", Bool False)
-    , ("a null::n", Null)
-    , ("a string::s", String "s")
-    , ("a double::d", Number 52.3)
-    , ("a long::l", Number 24.0)
-    ]
+  [ Null
+  , Object annotatedExampleObject
   ]
 
 

--- a/katip/src/Katip/Core.hs
+++ b/katip/src/Katip/Core.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE ExistentialQuantification  #-}
@@ -367,8 +368,9 @@ instance Monoid PayloadSelection where
 -- a ToJSON instance like:
 --
 -- > instance ToObject Foo
-class ToJSON a => ToObject a where
+class ToObject a where
     toObject :: a -> A.Object
+    default toObject :: ToJSON a => a -> A.Object
     toObject v = case toJSON v of
       A.Object o -> o
       _        -> mempty


### PR DESCRIPTION
There is not need to have ToJSON as superclass because it is
only used for default implementation.

closes #33 