### PR TITLE
Faster time encoding for Handle Scribe

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -37,6 +37,7 @@ library
   exposed-modules:
     Katip
     Katip.Core
+    Katip.Format.Time
     Katip.Monadic
     Katip.Scribes.Handle
 
@@ -63,7 +64,6 @@ library
                , template-haskell >= 2.8 && < 2.12
                , text >= 0.11 && <1.3
                , time >= 1 && < 1.7
-               , time-locale-compat >= 0.1.0.1 && < 0.2
                , transformers >= 0.3 && < 0.6
                , transformers-compat
                , unix >= 2.5 && < 2.8
@@ -97,6 +97,7 @@ test-suite test
                , template-haskell
                , text
                , time
+               , time-locale-compat >= 0.1.0.1 && < 0.2
                , temporary
                , directory
                , regex-tdfa

--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -90,7 +90,9 @@ test-suite test
   build-depends: base
                , katip
                , aeson
+               , bytestring
                , tasty >= 0.10.1.2
+               , tasty-golden
                , tasty-hunit
                , tasty-quickcheck
                , quickcheck-instances
@@ -102,7 +104,7 @@ test-suite test
                , directory
                , regex-tdfa
                , unordered-containers
-
+               , microlens
 
 benchmark bench
   type: exitcode-stdio-1.0

--- a/katip/src/Katip/Format/Time.hs
+++ b/katip/src/Katip/Format/Time.hs
@@ -1,0 +1,213 @@
+-- | Time and memory efficient time encoding helper functions.
+--
+module Katip.Format.Time
+    ( formatAsLogTime
+    , formatAsIso8601
+    ) where
+
+import           Control.Monad.ST        (ST)
+
+import           Data.Int                (Int64)
+import qualified Data.Text.Array         as TA
+import           Data.Text               (Text)
+import           Data.Text.Internal      (Text(..))
+import           Data.Time               (UTCTime(..), toGregorian, Day, DiffTime)
+import           Data.Word               (Word16)
+import           Unsafe.Coerce           (unsafeCoerce)
+
+-- Note: All functions here are optimized to never allocate anything
+-- on heap. At least on ghc 8.0.1 no extra strictness annotations are
+-- seem to be needed.
+--
+-- Exported functions are INLINEABLE
+
+
+-- | Format 'UTCTime' into a short human readable format.
+--
+-- >>> formatAsLogTime $ UTCTime (fromGregorian 2016 1 23) 5025.123456789012
+-- "2016-01-23 01:23:45"
+--
+formatAsLogTime :: UTCTime -> Text
+formatAsLogTime (UTCTime day time) = toText $ TA.run2 $ do
+     buf <- TA.new 19 -- length "2016-10-20 12:34:56"
+     _ <- writeDay buf 0 day
+     TA.unsafeWrite buf 10 0x20 -- space
+     _ <- writeTimeOfDay False buf 11 (diffTimeOfDay64 time)
+     pure (buf, 19)
+  where
+     toText (arr, len) = Text arr 0 len
+
+{-# INLINEABLE formatAsLogTime #-}
+
+-- | Format 'UTCTime' into a Iso8601 format.
+--
+--  Note that this function may overcommit up to 12*2 bytes, depending
+--  on sub-second precision. If this is an issue, make a copy with a
+--  'Data.Text.copy'.
+--
+-- >>> formatAsIso8601 $ UTCTime (fromGregorian 2016 1 23) 5025.123456789012
+-- "2016-11-23T01:23:45.123456789012Z"
+-- >>> formatAsIso8601 $ UTCTime (fromGregorian 2016 1 23) 5025.123
+-- "2016-01-23T01:23:45.123Z"
+-- >>> formatAsIso8601 $ UTCTime (fromGregorian 2016 1 23) 5025
+-- "2016-01-23T01:23:45Z"
+
+--
+formatAsIso8601 :: UTCTime -> Text
+formatAsIso8601 (UTCTime day time) = toText $ TA.run2 $ do
+   buf <- TA.new 33 -- length "2016-10-20 12:34:56.123456789012Z"
+   _ <- writeDay buf 0 day
+   TA.unsafeWrite buf  10  0x54 -- T
+   next <- writeTimeOfDay True buf 11 (diffTimeOfDay64 time)
+   TA.unsafeWrite buf next 0x5A -- Z
+   pure (buf, next+1)
+  where
+     toText (arr, len) = Text arr 0 len
+
+{-# INLINEABLE formatAsIso8601 #-}
+
+-- | Writes the @YYYY-MM-DD@ part of timestamp
+writeDay :: TA.MArray s -> Int -> Day -> ST s Int
+writeDay buf off day =
+  do
+    TA.unsafeWrite buf (off + 0) (digit y1)
+    TA.unsafeWrite buf (off + 1) (digit y2)
+    TA.unsafeWrite buf (off + 2) (digit y3)
+    TA.unsafeWrite buf (off + 3) (digit y4)
+    TA.unsafeWrite buf (off + 4) 0x2d -- dash
+    TA.unsafeWrite buf (off + 5) m1
+    TA.unsafeWrite buf (off + 6) m2
+    TA.unsafeWrite buf (off + 7) 0x2d -- dash
+    TA.unsafeWrite buf (off + 8) d1
+    TA.unsafeWrite buf (off + 9) d2
+    pure (off + 10)
+  where
+    (yr,m,d) = toGregorian day
+    (y1, ya) = fromIntegral (abs yr) `quotRem` 1000
+    (y2, yb) = ya `quotRem` 100
+    (y3, y4) = yb `quotRem` 10
+    T m1 m2  = twoDigits m
+    T d1 d2  = twoDigits d
+{-# INLINE writeDay #-}
+
+-- | Write time of day, optionally with sub seconds
+writeTimeOfDay :: Bool -> TA.MArray s -> Int -> TimeOfDay64 -> ST s Int
+writeTimeOfDay doSubSeconds buf off (TOD hh mm ss) =
+  do
+
+    TA.unsafeWrite buf  off      h1
+    TA.unsafeWrite buf (off + 1) h2
+    TA.unsafeWrite buf (off + 2) 0x3A -- colon
+    TA.unsafeWrite buf (off + 3) m1
+    TA.unsafeWrite buf (off + 4) m2
+    TA.unsafeWrite buf (off + 5) 0x3A -- colon
+    TA.unsafeWrite buf (off + 6) s1
+    TA.unsafeWrite buf (off + 7) s2
+    if doSubSeconds && frac /= 0
+    then writeFracSeconds buf (off + 8) frac
+    else pure (off + 8)
+  where
+   T h1 h2 = twoDigits hh
+   T m1 m2 = twoDigits mm
+   T s1 s2 = twoDigits (fromIntegral real)
+   (real,frac) = ss `quotRem` pico
+   pico       = 1000000000000 -- number of picoseconds  in 1 second
+
+
+writeFracSeconds :: TA.MArray s -> Int -> Int64 -> ST s Int
+writeFracSeconds buf off frac =
+  do
+    TA.unsafeWrite buf off 0x2e -- period
+    if mills == 0
+    then do
+      writeTrunc6 buf (off + 1) (fromIntegral mics)
+    else do
+      writeDigit6 buf (off + 1) (fromIntegral mics)
+      writeTrunc6 buf (off + 7) (fromIntegral mills)
+
+  where
+    (mics, mills)  = frac `quotRem` micro
+    micro          = 1000000 -- number of microseconds in 1 second
+
+
+writeDigit6 :: TA.MArray s -> Int -> Int -> ST s ()
+writeDigit6 buf off i =
+  do
+    writeDigit3 buf off f1
+    writeDigit3 buf (off+3) f2
+  where
+   (f1, f2) = i `quotRem` 1000
+
+{-# INLINE writeDigit6 #-}
+
+writeDigit3 :: TA.MArray s -> Int -> Int -> ST s ()
+writeDigit3 buf off i =
+  do
+    TA.unsafeWrite buf off (digit d1)
+    TA.unsafeWrite buf (off+1) (digit d2)
+    TA.unsafeWrite buf (off+2) (digit d3)
+  where
+    (d1, d) = i `quotRem` 100
+    (d2, d3) = d `quotRem` 10
+
+{-# INLINE writeDigit3 #-}
+
+writeTrunc6 :: TA.MArray s -> Int -> Int -> ST s Int
+writeTrunc6 buf off i =
+  if f2 == 0
+    then writeTrunc3 buf off f1
+    else do
+      writeDigit3 buf off f1
+      writeTrunc3 buf (off+3) f2
+  where
+   (f1, f2) = i `quotRem` 1000
+
+{-# INLINE writeTrunc6 #-}
+
+
+writeTrunc3 :: TA.MArray s -> Int -> Int -> ST s Int
+writeTrunc3 buf off i
+    | d == 0 = do
+        TA.unsafeWrite buf off (digit d1)
+        pure (off+1)
+    | d3 == 0 = do
+        TA.unsafeWrite buf off (digit d1)
+        TA.unsafeWrite buf (off+1) (digit d2)
+        pure (off+2)
+
+    | otherwise = do
+        TA.unsafeWrite buf off (digit d1)
+        TA.unsafeWrite buf (off+1) (digit d2)
+        TA.unsafeWrite buf (off+2) (digit d3)
+        pure (off+3)
+  where
+    (d1, d) = i `quotRem` 100
+    (d2, d3) = d `quotRem` 10
+
+{-# INLINE writeTrunc3 #-}
+
+
+-- Following code was adapted from aeson package.
+--
+-- Copyright:   (c) 2015-2016 Bryan O'Sullivan
+-- License:     BSD3
+
+data T = T {-# UNPACK #-} !Word16 {-# UNPACK #-} !Word16
+
+twoDigits :: Int -> T
+twoDigits a     = T (digit hi) (digit lo)
+  where (hi,lo) = a `quotRem` 10
+
+digit :: Int -> Word16
+digit x = fromIntegral (x + 48)
+
+
+data TimeOfDay64 = TOD {-# UNPACK #-} !Int
+                       {-# UNPACK #-} !Int
+                       {-# UNPACK #-} !Int64
+
+diffTimeOfDay64 :: DiffTime -> TimeOfDay64
+diffTimeOfDay64 t = TOD (fromIntegral h) (fromIntegral m) s
+  where (h,mp) = fromIntegral pico `quotRem` 3600000000000000
+        (m,s)  = mp `quotRem` 60000000000000
+        pico   = unsafeCoerce t :: Integer

--- a/katip/src/Katip/Format/Time.hs
+++ b/katip/src/Katip/Format/Time.hs
@@ -33,7 +33,7 @@ formatAsLogTime (UTCTime day time) = toText $ TA.run2 $ do
      _ <- writeDay buf 0 day
      TA.unsafeWrite buf 10 0x20 -- space
      _ <- writeTimeOfDay False buf 11 (diffTimeOfDay64 time)
-     pure (buf, 19)
+     return (buf, 19)
   where
      toText (arr, len) = Text arr 0 len
 
@@ -60,7 +60,7 @@ formatAsIso8601 (UTCTime day time) = toText $ TA.run2 $ do
    TA.unsafeWrite buf  10  0x54 -- T
    next <- writeTimeOfDay True buf 11 (diffTimeOfDay64 time)
    TA.unsafeWrite buf next 0x5A -- Z
-   pure (buf, next+1)
+   return (buf, next+1)
   where
      toText (arr, len) = Text arr 0 len
 
@@ -80,7 +80,7 @@ writeDay buf off day =
     TA.unsafeWrite buf (off + 7) 0x2d -- dash
     TA.unsafeWrite buf (off + 8) d1
     TA.unsafeWrite buf (off + 9) d2
-    pure (off + 10)
+    return (off + 10)
   where
     (yr,m,d) = toGregorian day
     (y1, ya) = fromIntegral (abs yr) `quotRem` 1000
@@ -105,7 +105,7 @@ writeTimeOfDay doSubSeconds buf off (TOD hh mm ss) =
     TA.unsafeWrite buf (off + 7) s2
     if doSubSeconds && frac /= 0
     then writeFracSeconds buf (off + 8) frac
-    else pure (off + 8)
+    else return (off + 8)
   where
    T h1 h2 = twoDigits hh
    T m1 m2 = twoDigits mm
@@ -169,17 +169,17 @@ writeTrunc3 :: TA.MArray s -> Int -> Int -> ST s Int
 writeTrunc3 buf off i
     | d == 0 = do
         TA.unsafeWrite buf off (digit d1)
-        pure (off+1)
+        return (off+1)
     | d3 == 0 = do
         TA.unsafeWrite buf off (digit d1)
         TA.unsafeWrite buf (off+1) (digit d2)
-        pure (off+2)
+        return (off+2)
 
     | otherwise = do
         TA.unsafeWrite buf off (digit d1)
         TA.unsafeWrite buf (off+1) (digit d2)
         TA.unsafeWrite buf (off+2) (digit d3)
-        pure (off+3)
+        return (off+3)
   where
     (d1, d) = i `quotRem` 100
     (d2, d3) = d `quotRem` 10

--- a/katip/src/Katip/Scribes/Handle.hs
+++ b/katip/src/Katip/Scribes/Handle.hs
@@ -13,12 +13,11 @@ import           Data.Monoid
 import           Data.Text               (Text)
 import           Data.Text.Lazy.Builder
 import           Data.Text.Lazy.IO       as T
-import           Data.Time
-import qualified Data.Time.Locale.Compat as LC
 import           System.IO
 import           System.IO.Unsafe        (unsafePerformIO)
 -------------------------------------------------------------------------------
 import           Katip.Core
+import           Katip.Format.Time       (formatAsLogTime)
 -------------------------------------------------------------------------------
 
 
@@ -83,7 +82,7 @@ formatItem withColor verb Item{..} =
     maybe mempty (brackets . fromString . locationToString) _itemLoc <>
     fromText " " <> (unLogStr _itemMessage)
   where
-    nowStr = fromString $ formatTime LC.defaultTimeLocale "%Y-%m-%d %H:%M:%S" _itemTime
+    nowStr = fromText (formatAsLogTime _itemTime)
     ks = map brackets $ getKeys verb _itemPayload
     renderSeverity' s = case s of
       EmergencyS -> red $ renderSeverity s

--- a/katip/test/Katip/Tests/Format/Time.hs
+++ b/katip/test/Katip/Tests/Format/Time.hs
@@ -1,0 +1,73 @@
+
+module Katip.Tests.Format.Time
+    ( tests
+    ) where
+
+import           Data.Aeson (toJSON)
+import qualified Data.Text as Text
+import           Data.Time
+import           Data.Time.Clock.POSIX
+import qualified Data.Time.Locale.Compat as LC
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+
+import           Katip.Format.Time
+
+tests :: TestTree
+tests = testGroup "Katip.Format.Time"
+  [ testCase "formatAsLogTime" $ do
+      assertEqual "time 1" (formatDT t1) (formatAsLogTime t1)
+      assertEqual "time 2" (formatDT t2) (formatAsLogTime t2)
+      assertEqual "time 3" (formatDT t3) (formatAsLogTime t3)
+
+  , testCase "formatAsIso8601" $ do
+      assertEqual "time 1" (formatDTISO t1) (formatAsIso8601 t1)
+      assertEqual "time 2" (formatDTISO t2) (formatAsIso8601 t2)
+      assertEqual "time 3" (formatDTISO t3) (formatAsIso8601 t3)
+
+  , testCase "formatAsIso8601 Aeson" $ do
+      assertEqual "time 1" (toJSON t1) (toJSON $ formatAsIso8601 t1)
+      assertEqual "time 2" (toJSON t2) (toJSON $ formatAsIso8601 t2)
+      assertEqual "time 3" (toJSON t3) (toJSON $ formatAsIso8601 t3)
+
+
+  , testProperty "LogTime same as Date.Time" $ \(ArbUTCTime t) ->
+      prop_format_log t
+
+  , testProperty "ISO 8601 same as Date.Time" $ \(ArbUTCTime t) ->
+      prop_format_iso t
+
+  , testProperty "ISO 8601 same as Aeson" $ \(ArbUTCTime t) ->
+      prop_format_aeson t
+
+  ]
+  where
+    t1 = UTCTime (fromGregorian 2016 12 34) 5025.123456789012
+    t2 = UTCTime (fromGregorian 2016 1 23) 5025.123
+    t3 = UTCTime (fromGregorian 16 12 1) 025
+
+formatDT :: UTCTime -> Text.Text
+formatDT = Text.pack . formatTime LC.defaultTimeLocale "%0Y-%m-%d %H:%M:%S"
+
+formatDTISO :: UTCTime -> Text.Text
+formatDTISO = Text.pack . formatTime LC.defaultTimeLocale "%0Y-%m-%dT%H:%M:%S%QZ"
+
+prop_format_log :: UTCTime -> Property
+prop_format_log a = formatDT a === formatAsLogTime a
+
+prop_format_iso :: UTCTime -> Property
+prop_format_iso a = formatDTISO a === formatAsIso8601 a
+
+prop_format_aeson :: UTCTime -> Property
+prop_format_aeson a = toJSON a === toJSON (formatAsIso8601 a)
+
+
+newtype ArbUTCTime = ArbUTCTime {
+      unArbUTCTime :: UTCTime
+    } deriving (Show)
+
+instance Arbitrary ArbUTCTime where
+    arbitrary = ArbUTCTime . posixSecondsToUTCTime . fromInteger
+                <$> arbitrary

--- a/katip/test/Katip/Tests/Format/Time.hs
+++ b/katip/test/Katip/Tests/Format/Time.hs
@@ -77,5 +77,5 @@ newtype ArbUTCTime = ArbUTCTime {
     } deriving (Show)
 
 instance Arbitrary ArbUTCTime where
-    arbitrary = ArbUTCTime . posixSecondsToUTCTime . fromInteger
-                <$> arbitrary
+    arbitrary = fmap (ArbUTCTime . posixSecondsToUTCTime . fromInteger)
+                     arbitrary

--- a/katip/test/Katip/Tests/Format/Time.hs
+++ b/katip/test/Katip/Tests/Format/Time.hs
@@ -3,8 +3,8 @@ module Katip.Tests.Format.Time
     ( tests
     ) where
 
-import           Data.Aeson (toJSON)
-import qualified Data.Text as Text
+import           Data.Aeson              (toJSON)
+import qualified Data.Text               as Text
 import           Data.Time
 import           Data.Time.Clock.POSIX
 import qualified Data.Time.Locale.Compat as LC
@@ -21,16 +21,22 @@ tests = testGroup "Katip.Format.Time"
       assertEqual "time 1" (formatDT t1) (formatAsLogTime t1)
       assertEqual "time 2" (formatDT t2) (formatAsLogTime t2)
       assertEqual "time 3" (formatDT t3) (formatAsLogTime t3)
+      assertEqual "time 4" (formatDT t4) (formatAsLogTime t4)
+      assertEqual "time 5" (formatDT t5) (formatAsLogTime t5)
 
   , testCase "formatAsIso8601" $ do
       assertEqual "time 1" (formatDTISO t1) (formatAsIso8601 t1)
       assertEqual "time 2" (formatDTISO t2) (formatAsIso8601 t2)
       assertEqual "time 3" (formatDTISO t3) (formatAsIso8601 t3)
+      assertEqual "time 4" (formatDTISO t4) (formatAsIso8601 t4)
+      assertEqual "time 5" (formatDTISO t5) (formatAsIso8601 t5)
 
   , testCase "formatAsIso8601 Aeson" $ do
       assertEqual "time 1" (toJSON t1) (toJSON $ formatAsIso8601 t1)
       assertEqual "time 2" (toJSON t2) (toJSON $ formatAsIso8601 t2)
       assertEqual "time 3" (toJSON t3) (toJSON $ formatAsIso8601 t3)
+      assertEqual "time 4" (toJSON t4) (toJSON $ formatAsIso8601 t4)
+      assertEqual "time 5" (toJSON t5) (toJSON $ formatAsIso8601 t5)
 
 
   , testProperty "LogTime same as Date.Time" $ \(ArbUTCTime t) ->
@@ -47,6 +53,8 @@ tests = testGroup "Katip.Format.Time"
     t1 = UTCTime (fromGregorian 2016 12 34) 5025.123456789012
     t2 = UTCTime (fromGregorian 2016 1 23) 5025.123
     t3 = UTCTime (fromGregorian 16 12 1) 025
+    t4 = UTCTime (fromGregorian 2000 1 1) 0.000000000001
+    t5 = UTCTime (fromGregorian 2000 12 31) 0.100000000001
 
 formatDT :: UTCTime -> Text.Text
 formatDT = Text.pack . formatTime LC.defaultTimeLocale "%0Y-%m-%d %H:%M:%S"

--- a/katip/test/Katip/Tests/Scribes/Handle-text.golden
+++ b/katip/test/Katip/Tests/Scribes/Handle-text.golden
@@ -1,0 +1,40 @@
+[2016-06-12 12:34:56][foo][Debug][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Notice][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Warning][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Error][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Critical][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Alert][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Emergency][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][0][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][2147483647][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][www.example.com][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][127.0.0.1][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][0][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][1][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][1337][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][2147483647][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+with newline
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note]  a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message a really long message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] сообщение
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] 哈囉世界
+[2000-01-01 00:00:00][foo][Info][example][7331][1337][note.deep:some note] message
+[2123-12-31 23:59:59][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-10-10 01:01:05][foo][Info][example][7331][1337][note.deep:some note] message
+[2100-12-31 12:59:10][foo][Info][example][7331][1337][note.deep:some note] message
+[1982-01-01 12:30:00][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo.bar][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][фу.бар][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][with
+newline][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note][main:Some.Module path/Some/Module.hs:30:1] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note][main:Some.Module путь/Some/Module.hs:3000:9000] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][sub:null][text:][num:0.0][float:0.0] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][sub.note.deep:some note][text:note][num:10.0][float:5.5] message

--- a/katip/test/Katip/Tests/Scribes/Handle.hs
+++ b/katip/test/Katip/Tests/Scribes/Handle.hs
@@ -6,17 +6,26 @@ module Katip.Tests.Scribes.Handle
 -------------------------------------------------------------------------------
 import           Control.Monad
 import           Data.Aeson
+import qualified Data.ByteString.Lazy       as BL
 import           Data.Monoid
-import           Data.Text        (Text)
-import qualified Data.Text.IO     as T
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+import qualified Data.Text.IO               as T
+import qualified Data.Text.Lazy             as LT
+import qualified Data.Text.Lazy.Builder     as LT
+import           Data.Time
+import           Language.Haskell.TH.Syntax (Loc (..))
+import           Lens.Micro                 ((.~))
 import           System.Directory
 import           System.IO
 import           System.IO.Temp
 import           Test.Tasty
+import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
 import           Text.Regex.TDFA
 -------------------------------------------------------------------------------
 import           Katip
+import           Katip.Scribes.Handle
 -------------------------------------------------------------------------------
 
 
@@ -31,6 +40,10 @@ tests = testGroup "Katip.Scribes.Handle"
        let pat = "\\[[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\\]\\[katip-test.test\\]\\[Info\\]\\[.+\\]\\[[[:digit:]]+\\]\\[ThreadId [[:digit:]]+\\]\\[note.deep:some note\\] test message" :: String
        let matches = res =~ pat
        assertBool (res <> " did not match") matches
+  , withResource setupTempFile teardownTempFile $ \setup ->
+       goldenVsString "Text-golden"
+                      "test/Katip/Tests/Scribes/Handle-text.golden"
+                      (setup >>= writeTextLog)
   ]
 
 
@@ -74,3 +87,146 @@ teardown :: (FilePath, Handle, LogEnv) -> IO ()
 teardown (_, h, _) = do
   chk <- hIsOpen h
   when chk $ hClose h
+
+
+
+-- Following code tests Handle scribe output against a golden file.
+-- This test will fail on non utf8 locales because golden file is in utf-8.
+-- It generates all meaningfull variations of Item, and also tests
+-- writing of payload of different Aeson constructors
+--
+-- Note: currently Handle scribe does not write Array items at all
+-------------------------------------------------------------------------------
+data AllTypesLogItem = AllTypesLogItem
+    { atlText  :: Text
+    , atlNum   :: Int
+    , atlFloat :: Float
+    , atlList  :: [Text]
+    , atlSub   :: Maybe DummyLogItem
+    }
+
+
+instance ToJSON AllTypesLogItem where
+  toJSON it = object
+    [ "text"     .= atlText it
+    , "num"      .= atlNum it
+    , "float"    .= atlFloat it
+    , "list"     .= atlList it
+    , "sub"      .= atlSub it
+    ]
+
+
+instance ToObject AllTypesLogItem
+
+
+instance LogItem AllTypesLogItem where
+  payloadKeys _ _ = AllKeys
+
+
+-------------------------------------------------------------------------------
+theItem :: Item DummyLogItem
+theItem = Item (Namespace ["app"])
+               (Environment "production")
+               (InfoS)
+               (ThreadIdText "1337")
+               "example"
+               7331
+               dummyLogItem
+               "message"
+               (mkUTCTime 2016 6 12 12 34 56)
+               (Namespace ["foo"])
+               Nothing
+
+genItems :: [Item DummyLogItem]
+genItems = concat $
+  [ [ itemSeverity .~ s $ theItem
+          | s <- [minBound .. maxBound]
+    ]
+  , [ itemThread .~ (ThreadIdText . T.pack $ show t) $ theItem
+          | t <- [0, 1, 1337, 2147483647]
+    ]
+  , [ itemHost .~ h $ theItem
+          | h <- ["example", "www.example.com", "127.0.0.1"]
+    ]
+  , [ itemProcess .~ p $ theItem
+          | p <- [0, 1, 1337, 2147483647]
+    ]
+  , [ itemMessage .~ LogStr m $ theItem
+          | m <- [ "message"
+                 , "message\nwith newline"
+                 , LT.fromLazyText (LT.replicate 40 " a really long message")
+                 , "сообщение"
+                 , "哈囉世界"
+                 ]
+    ]
+  , [ itemTime .~ t $ theItem
+          | t <- genDates
+    ]
+  , [ itemNamespace .~ Namespace ns $ theItem
+          | ns <- [ ["foo"]
+                  , ["foo", "bar"]
+                  , ["фу", "бар"]
+                  , ["with\nnewline"] ]
+    ]
+  , [ itemLoc .~ l $ theItem | l <- genLocs
+    ]
+  ]
+
+genDates :: [UTCTime]
+genDates =
+  [ mkUTCTime 2000 1   1 0   0  0.0
+  , mkUTCTime 2123 12 31 23  59 59.999999999999
+  , mkUTCTime 2016 10 10 1   1  5.0
+  , mkUTCTime 2100 12 31 12  59 10.1
+  , mkUTCTime 1982 1  1  12  30 0.000000000001
+  ]
+
+genLocs :: [Maybe Loc]
+genLocs =
+  [ Nothing
+  , Just $ Loc "path/Some/Module.hs"
+               "main"
+               "Some.Module"
+               (30,1) (30,14)
+  , Just $ Loc "путь/Some/Module.hs"
+               "main"
+               "Some.Module"
+               (3000,9000) (4000,1)
+  ]
+
+genTypedItems :: [Item AllTypesLogItem]
+genTypedItems =
+  [ itemPayload .~ p $ theItem
+        | p <- [ AllTypesLogItem "" 0 0.0 [] Nothing
+               , AllTypesLogItem "note" 10 5.5 ["one", "two", "three"]
+                     (Just dummyLogItem)
+               ]
+  ]
+
+mkUTCTime :: Integer -> Int -> Int -> DiffTime -> DiffTime -> DiffTime -> UTCTime
+mkUTCTime y mt d h mn s = UTCTime day dt
+  where
+    day = fromGregorian y mt d
+    dt = h * 60 * 60 + mn * 60 + s
+
+-------------------------------------------------------------------------------
+writeTextLog :: (FilePath, Handle) -> IO (BL.ByteString)
+writeTextLog (path, h) = do
+    mapM_ (T.hPutStrLn h . formatOne) genItems
+    mapM_ (T.hPutStrLn h . formatOne) genTypedItems
+    hClose h
+    BL.readFile path
+  where
+    formatOne :: LogItem a => Item a -> Text
+    formatOne = LT.toStrict . LT.toLazyText . formatItem False V3
+
+setupTempFile :: IO (FilePath, Handle)
+setupTempFile = do
+    tempDir <- getTemporaryDirectory
+    (fp, h) <- openBinaryTempFile tempDir "katip.log"
+    return (fp, h)
+
+teardownTempFile :: (FilePath, Handle) -> IO ()
+teardownTempFile (_, h) = do
+    chk <- hIsOpen h
+    when chk $ hClose h

--- a/katip/test/Main.hs
+++ b/katip/test/Main.hs
@@ -4,6 +4,7 @@ module Main (main) where
 import           Test.Tasty
 -------------------------------------------------------------------------------
 import qualified Katip.Tests
+import qualified Katip.Tests.Format.Time
 import qualified Katip.Tests.Scribes.Handle
 -------------------------------------------------------------------------------
 
@@ -15,5 +16,6 @@ testSuite :: TestTree
 testSuite = testGroup "katip"
   [
     Katip.Tests.tests
+  , Katip.Tests.Format.Time.tests
   , Katip.Tests.Scribes.Handle.tests
   ]


### PR DESCRIPTION
This implements time encoding functions using low-level Data.Test interface.

Encoding functions do not allocate anything except the result, and work really fast.

The Handle Scribe benchmark improved almost 4x times. From 24us to 6.1 us.

This should probably be used in JSON encoding, at least in the toJSON part.

The toEncoding part should use efficient implementation in Data.Aeson to avoid allocating Text or ByteString outside of Builder.

Fixes #3

Benchmark results before

```
benchmarking Katip.Scribes.Handle/Bytestring Builder
time                 23.85 μs   (23.41 μs .. 24.35 μs)
                     0.996 R²   (0.993 R² .. 0.999 R²)
mean                 24.11 μs   (23.68 μs .. 24.82 μs)
std dev              1.978 μs   (1.220 μs .. 2.994 μs)
variance introduced by outliers: 79% (severely inflated)
```

After

```
benchmarking Katip.Scribes.Handle/Bytestring Builder
time                 6.106 μs   (6.025 μs .. 6.223 μs)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 6.212 μs   (6.099 μs .. 6.524 μs)
std dev              569.2 ns   (258.0 ns .. 1.164 μs)
variance introduced by outliers: 85% (severely inflated)
```

We should add JSON benchmark and check if this may improve it also.
