### PR TITLE
Actually pass the implicit callstack to logLoc

### DIFF
--- a/katip/src/Katip/Core.hs
+++ b/katip/src/Katip/Core.hs
@@ -826,7 +826,11 @@ logT = [| \ a ns sev msg -> logItem a ns (Just $(getLocTH)) sev msg |]
 -- `logT` for maximum compatibility.
 --
 -- @logLoc obj mempty InfoS "Hello world"@
+#if MIN_VERSION_base(4, 8, 0)
+logLoc :: (Applicative m, LogItem a, Katip m, ?loc :: CallStack)
+#else
 logLoc :: (Applicative m, LogItem a, Katip m)
+#endif
        => a
        -> Namespace
        -> Severity


### PR DESCRIPTION
... in order to have the right call site in scope.

Hey @MichaelXavier !

I am embarrassed to admit that in my previous PR (see #18 ) I omitted a crucial detail 🙈 : In `logLoc`
I'm not _actually_ passing the implicit callstack to `logLoc`, which means that the call site showed in the logs will be the one of `getLoc` . I had the following code in a project of mine:

``` haskell
--------------------------------------------------------------------------------
-- Execute a monadic action, measuring the time it took.
timeMeasured :: (Katip m, MonadIO m, KatipContext m, ?loc :: CallStack)
             => String
             -> m a
             -> m a
timeMeasured label action = do
  startTime <- liftIO getPOSIXTime
  res <- action
  endTime   <- liftIO getPOSIXTime
  ns <- getKatipNamespace
  let msg = label <> " took " <> (show $ endTime - startTime) <> " seconds to execute."
  logLoc () ns InfoS (fromString msg)
  return res
```

Upon running it, with the current version of Katip, this is the output:

![screen shot 2017-02-13 at 17 10 19](https://cloud.githubusercontent.com/assets/442035/22892096/a84aeba8-f211-11e6-93be-371282b448fa.png)

Drat! Not quite right. After passing the `?loc` around (as per this patch):

![screen shot 2017-02-13 at 17 21 17](https://cloud.githubusercontent.com/assets/442035/22892115/b77fa14a-f211-11e6-89e0-2f0294fe9120.png)

Where `Transcoder.hs` is actually the file calling `timeMeasured`, which is instead defined in a different file.

Am I making sense? I'm actually surprised nobody noticed first, maybe I'm flogging a dead horse here?

Cheers!

Alfredo