### PR TITLE
fix doc: "lens_example" -> "example_lens.hs"

### DIFF
--- a/katip/examples/example.hs
+++ b/katip/examples/example.hs
@@ -25,7 +25,7 @@ import           Katip
 
 
 -- | An example of advanced katip usage. Be sure to check out
--- lens_example for a slightly cleaner and more general pattern.
+-- example_lens.hs for a slightly cleaner and more general pattern.
 main :: IO ()
 main = do
   le <- initLogEnv "MyApp" "production"


### PR DESCRIPTION
There is no file called `lens_example`, so I'm assuming this is what it's supposed to be.