### PR TITLE
example_lens: remove reference to lens_example

### DIFF
--- a/katip/examples/example_lens.hs
+++ b/katip/examples/example_lens.hs
@@ -40,8 +40,7 @@ makeClassy ''MyState
 
 
 -------------------------------------------------------------------------------
--- | An example of advanced katip usage. Be sure to check out
--- lens_example for a slightly cleaner and more general pattern.
+-- | An example of advanced katip usage with Lens.
 main :: IO ()
 main = do
   le <- initLogEnv "MyApp" "production"


### PR DESCRIPTION
This looks like it was an accidental unmodified copy-paste from `example.hs`, as this comment appears to be instructing you to look at the file you're already reading.