### PR TITLE
Add local support for #51

### DIFF
--- a/katip/src/Katip/Monadic.hs
+++ b/katip/src/Katip/Monadic.hs
@@ -395,7 +395,7 @@ runKatipContextT le ctx ns = flip runReaderT lts . unKatipContextT
 -------------------------------------------------------------------------------
 -- | Append a namespace segment to the current namespace for the given
 -- monadic action, then restore the previous state
--- afterwards.
+-- afterwards. Works with anything implementing KatipContext.
 katipAddNamespace
     :: (KatipContext m)
     => Namespace
@@ -414,7 +414,8 @@ katipAddNamespace ns = localKatipNamespace (<> ns)
 -- added. If you instead roll your own recursion and you're recursing
 -- in the action you provide, you'll instead accumulate tons of
 -- redundant contexts and even if they all merge on log, they are
--- stored in a sequence and will leak memory.
+-- stored in a sequence and will leak memory. Works with anything
+-- implementing KatipContext.
 katipAddContext
     :: ( LogItem i
        , KatipContext m

--- a/katip/src/Katip/Monadic.hs
+++ b/katip/src/Katip/Monadic.hs
@@ -128,30 +128,70 @@ class Katip m => KatipContext m where
   getKatipContext :: m LogContexts
   getKatipNamespace   :: m Namespace
 
---TODO: is this INLINABLE?
-#define TRANS(T) \
-  instance (KatipContext m, Katip (T m)) => KatipContext (T m) where \
-    getKatipContext = lift getKatipContext; \
-    getKatipNamespace = lift getKatipNamespace
+instance (KatipContext m, Katip (IdentityT m)) => KatipContext (IdentityT m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
 
-#define TRANS_CTX(CTX, T) \
-  instance (CTX, KatipContext m, Katip (T m)) => KatipContext (T m) where \
-    getKatipContext = lift getKatipContext; \
-    getKatipNamespace = lift getKatipNamespace
 
-TRANS(IdentityT)
-TRANS(MaybeT)
-TRANS(EitherT e)
-TRANS(ListT)
-TRANS(ReaderT r)
-TRANS(ResourceT)
-TRANS(Strict.StateT s)
-TRANS(StateT s)
-TRANS(ExceptT s)
-TRANS_CTX(Monoid w, Strict.WriterT w)
-TRANS_CTX(Monoid w,        WriterT w)
-TRANS_CTX(Monoid w, Strict.RWST r w s)
-TRANS_CTX(Monoid w,        RWST r w s)
+instance (KatipContext m, Katip (MaybeT m)) => KatipContext (MaybeT m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (EitherT e m)) => KatipContext (EitherT e m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (ListT m)) => KatipContext (ListT m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (ReaderT r m)) => KatipContext (ReaderT r m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (ResourceT m)) => KatipContext (ResourceT m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (Strict.StateT s m)) => KatipContext (Strict.StateT s m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (StateT s m)) => KatipContext (StateT s m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (KatipContext m, Katip (ExceptT e m)) => KatipContext (ExceptT e m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (Monoid w, KatipContext m, Katip (Strict.WriterT w m)) => KatipContext (Strict.WriterT w m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (Monoid w, KatipContext m, Katip (WriterT w m)) => KatipContext (WriterT w m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (Monoid w, KatipContext m, Katip (Strict.RWST r w s m)) => KatipContext (Strict.RWST r w s m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
+
+instance (Monoid w, KatipContext m, Katip (RWST r w s m)) => KatipContext (RWST r w s m) where
+  getKatipContext = lift getKatipContext
+  getKatipNamespace = lift getKatipNamespace
+
 
 deriving instance (Monad m, KatipContext m) => KatipContext (KatipT m)
 
@@ -169,7 +209,6 @@ logItemM loc sev msg = do
     ctx <- getKatipContext
     ns <- getKatipNamespace
     logItem ctx ns loc sev msg
-
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This is for #51.

Tagging in folks I know use Katip, @mightybyte, @ozataman, @bitemyapp, @sopvop , @adinapoli 

Katip has been out for some time now and I've noticed some recurring patterns that should probably be brought into the library itself. It turns out that `MonadReader.local`-style temporary modification of logging environment is really useful. I've used it in every Katip-enabled app since creation. We started off with 2 typeclasses, `Katip` and the superset `KatipContext`, but they were only powerful enough to get the current `LogEnv`, `Namespace`, and `LogContexts`. This meant that I had to implement `katipAddLogContext`, `katipAddNamespace`, `katipNoLogging` for the sort of "sample" monad transformers that katip provides (`KatipT/KatipContextT`). These effectively became reference implementations as I tend to use custom monads, so I'd have to reimplement this functionality in every app.

I've carried through these new `local`-like operations into all the instances that ship for basically all of `mtl` and then some. I also added examples on how to implement these locals yourself in the example code. For folks using raw mtl transformers in their apps, they get context adding, namespace adding, log pausing for free. Everyone else get them for cheaper. This will be behind a breaking release.

Let me know if anyone has any objections. In the mean time, I'm going to proceed on the rest of the milestone and make adjustments to this PR as needed.