### PR TITLE
Fix JSON number formatting

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -74,6 +74,7 @@ library
                , mtl >= 2.0 && < 2.3
                , transformers-base >= 0.3 && < 0.6
                , resourcet >= 1.1 && < 1.2
+               , scientific >= 0.3.3.0
                , microlens >= 0.2.0.0 && < 0.5
                , microlens-th >= 0.1.0.0 && < 0.5
                , semigroups

--- a/katip/src/Katip/Scribes/Handle.hs
+++ b/katip/src/Katip/Scribes/Handle.hs
@@ -10,6 +10,7 @@ import           Control.Monad
 import           Data.Aeson
 import qualified Data.HashMap.Strict    as HM
 import           Data.Monoid
+import           Data.Scientific        as S
 import           Data.Text              (Text)
 import           Data.Text.Lazy.Builder
 import           Data.Text.Lazy.IO      as T
@@ -34,10 +35,13 @@ getKeys verb a = concat (renderPair A.<$> HM.toList (payloadObject verb a))
       case v of
         Object o -> concat [renderPair (k <> "." <> k', v')  | (k', v') <- HM.toList o]
         String t -> [fromText (k <> ":" <> t)]
-        Number n -> [fromText (k <> ":") <> fromString (show n)]
+        Number n -> [fromText (k <> ":") <> fromString (formatNumber n)]
         Bool b -> [fromText (k <> ":") <> fromString (show b)]
         Null -> [fromText (k <> ":null")]
         _ -> mempty -- Can't think of a sensible way to handle arrays
+    formatNumber :: Scientific -> String
+    formatNumber n =
+      formatScientific Generic (if isFloating n then Nothing else Just 0) n
 
 
 -------------------------------------------------------------------------------

--- a/katip/test/Katip/Tests/Scribes/Handle-text.golden
+++ b/katip/test/Katip/Tests/Scribes/Handle-text.golden
@@ -36,5 +36,5 @@ newline][Info][example][7331][1337][note.deep:some note] message
 [2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note] message
 [2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note][main:Some.Module path/Some/Module.hs:30:1] message
 [2016-06-12 12:34:56][foo][Info][example][7331][1337][note.deep:some note][main:Some.Module путь/Some/Module.hs:3000:9000] message
-[2016-06-12 12:34:56][foo][Info][example][7331][1337][sub:null][text:][num:0.0][float:0.0] message
-[2016-06-12 12:34:56][foo][Info][example][7331][1337][sub.note.deep:some note][text:note][num:10.0][float:5.5] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][sub:null][text:][num:0][float:0] message
+[2016-06-12 12:34:56][foo][Info][example][7331][1337][sub.note.deep:some note][text:note][num:10][float:5.5] message


### PR DESCRIPTION
* if the underlying number is floating point, format as it used to
* if the underlying number is integer, format without decimal places

Went with different way of doing that instead of suggested `either show show . floatingOrInteger`, because the defaults for Show constraints (Double), would mean it's "lossy":

```haskell
λ either show show $ floatingOrInteger (read "1.01e12" :: Scientific)
```

outputs:

```
"1010000000000"
```

whereas it could just as well output the original `1.01e12`.

There is no test case for this, because currently the JSON for tests is built by `ToJSON`, and not by hand (it also means it's unlikely it would ever be an issue).