### PR TITLE
Fix katip usage on windows.

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -87,7 +87,7 @@ library
     ghc-options: -Werror
   if os(windows)
     build-depends: Win32 >=2.3 && <2.5
-    other-modules: Katip.Compat
+    exposed-modules: Katip.Compat
   else
     build-depends: unix >= 2.5 && <2.8
 


### PR DESCRIPTION
Move Katip.Compat module to exposed modules. This module may
be needed for the user in case if it contructs LogEnv directly
without using helpers.