### PR TITLE
Added NoLoggingT

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -78,6 +78,7 @@ library
                , microlens >= 0.2.0.0 && < 0.5
                , microlens-th >= 0.1.0.0 && < 0.5
                , semigroups
+               , unliftio-core >= 0.1 && < 0.2
                , stm >= 2.4
 
   hs-source-dirs:      src

--- a/katip/src/Katip/Core.hs
+++ b/katip/src/Katip/Core.hs
@@ -33,6 +33,7 @@ import           Control.Exception.Safe
 import           Control.Monad                         (unless, void)
 import           Control.Monad.Base
 import           Control.Monad.IO.Class
+import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Control
 #if !MIN_VERSION_either(4, 5, 0)
@@ -833,6 +834,10 @@ instance (MonadBaseControl b m) => MonadBaseControl b (KatipT m) where
   liftBaseWith = defaultLiftBaseWith
   restoreM = defaultRestoreM
 
+instance MonadUnliftIO m => MonadUnliftIO (KatipT m) where
+  askUnliftIO = KatipT $
+                withUnliftIO $ \u ->
+                pure (UnliftIO (unliftIO u . unKatipT))
 
 -------------------------------------------------------------------------------
 -- | Execute 'KatipT' on a log env.

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ extra-deps:
   # These can be dropped probably as soon as they hit an LTS
   - bloodhound-0.15.0.2
   - http-types-0.12
+  - unliftio-core-0.1.1.0
 flags:
   katip:
     lib-Werror: true


### PR DESCRIPTION
The equivalent of `runNoLoggingT` from monad-logger.

I also snuck in `MonadUnliftIO` instances.

Original idea from @jkachmar