### PR TITLE
Unix-Compat Support + Win32 Minimum Version Bump

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -80,17 +80,15 @@ library
                , semigroups
                , unliftio-core >= 0.1 && < 0.2
                , stm >= 2.4
-
+               , unix-compat
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:        -Wall
   if flag(lib-Werror)
     ghc-options: -Werror
   if os(windows)
-    build-depends: Win32 >=2.3 && <2.6
+    build-depends: Win32 >= 2.5.0
     exposed-modules: Katip.Compat
-  else
-    build-depends: unix >= 2.5 && <2.8
 
 
 test-suite test

--- a/katip/src/Katip/Compat.hs
+++ b/katip/src/Katip/Compat.hs
@@ -9,22 +9,5 @@ import System.Win32.Process
 
 type ProcessID = ProcessId
 
-#if !MIN_VERSION_Win32(2,4,0)
-
-#if defined(i386_HOST_ARCH)
-# define WINDOWS_CCONV stdcall
-#elif defined(x86_64_HOST_ARCH)
-# define WINDOWS_CCONV ccall
-#else
-# error Unknown mingw32 arch
-#endif
-
-foreign import WINDOWS_CCONV unsafe "windows.h GetCurrentProcessId"
-    c_GetCurrentProcessId :: IO ProcessId
-
-getProcessID :: IO ProcessID
-getProcessID = c_GetCurrentProcessId
-#else
 getProcessID :: IO ProcessID
 getProcessID = getCurrentProcessId
-#endif


### PR DESCRIPTION
Hi All,

This PR bumps the minimum supported `Win32` version to `2.5.0` to establish compatibility with the `unix-compat` package. `unix-compat` re-exports `unix >= 2.4 && < 2.8` in the case where Windows is not the current OS. This would help us with windows compatibility in several libraries that depend on `katip`, such as [`ridley`](https://github.com/iconnect/ridley), for which we only need Prometheus metrics, but any downstream `unix` dependencies cause the build to fail immediately. I've also taken the liberty to remove some code in `Compat.hs` which was made obsolete by the update.

If you're not amenable to this, I'd love to work and find a solution that fits everyone's needs!

Thanks