### PR TITLE
PermitFunc in Scribe

### DIFF
--- a/katip-elasticsearch/examples/example.hs
+++ b/katip-elasticsearch/examples/example.hs
@@ -27,7 +27,7 @@ main = do
     bhe
     (IndexName "all-indices-prefixed-with")
     (MappingName "application-logs")
-    DebugS
+    (permitItem DebugS)
     V3
   let mkLogEnv = registerScribe "es" esScribe defaultScribeSettings =<< initLogEnv "MyApp" "production"
   bracket mkLogEnv closeScribes $ \le -> runKatipT le $ do

--- a/katip-elasticsearch/katip-elasticsearch.cabal
+++ b/katip-elasticsearch/katip-elasticsearch.cabal
@@ -35,7 +35,7 @@ library
     Katip.Scribes.ElasticSearch.Internal
   build-depends:
       base >=4.6 && <5
-    , katip >= 0.2.0.0 && <= 0.8
+    , katip >= 0.2.0.0 && < 0.9
     , bloodhound >= 0.13.0.0 && < 0.17
     , uuid >= 1.3.12 && < 1.4
     , aeson >=0.6

--- a/katip-elasticsearch/katip-elasticsearch.cabal
+++ b/katip-elasticsearch/katip-elasticsearch.cabal
@@ -35,7 +35,7 @@ library
     Katip.Scribes.ElasticSearch.Internal
   build-depends:
       base >=4.6 && <5
-    , katip >= 0.2.0.0 && < 0.8
+    , katip >= 0.2.0.0 && <= 0.8
     , bloodhound >= 0.13.0.0 && < 0.17
     , uuid >= 1.3.12 && < 1.4
     , aeson >=0.6

--- a/katip-elasticsearch/katip-elasticsearch.cabal
+++ b/katip-elasticsearch/katip-elasticsearch.cabal
@@ -1,7 +1,7 @@
 name:                katip-elasticsearch
 synopsis:            ElasticSearch scribe for the Katip logging framework.
 description:         See README.md for more details.
-version:             0.8.0.0
+version:             0.6.0.0
 license:             BSD3
 license-file:        LICENSE
 author:              Ozgun Ataman, Michael Xavier

--- a/katip-elasticsearch/katip-elasticsearch.cabal
+++ b/katip-elasticsearch/katip-elasticsearch.cabal
@@ -1,7 +1,7 @@
 name:                katip-elasticsearch
 synopsis:            ElasticSearch scribe for the Katip logging framework.
 description:         See README.md for more details.
-version:             0.5.1.1
+version:             0.8.0.0
 license:             BSD3
 license-file:        LICENSE
 author:              Ozgun Ataman, Michael Xavier

--- a/katip-elasticsearch/test/Main.hs
+++ b/katip-elasticsearch/test/Main.hs
@@ -161,7 +161,7 @@ setupSearch
 setupSearch prx modScribeCfg = do
     bh prx (dropESSchema prx)
     mgr <- newManager defaultManagerSettings
-    mkEsScribe cfg (mkBHEnv prx (svr prx) mgr) (ixn prx) (mn prx) DebugS V3
+    mkEsScribe cfg (mkBHEnv prx (svr prx) mgr) (ixn prx) (mn prx) (permitItem DebugS) V3
   where
     cfg :: EsScribeCfg v
     cfg = modScribeCfg $

--- a/katip/bench/Main.hs
+++ b/katip/bench/Main.hs
@@ -92,7 +92,7 @@ setup dest = do
       return (tmp </> "katip-bench.log")
     DevNull -> return ("/dev/null")
   h <- openFile outFile WriteMode
-  s <- mkHandleScribe ColorIfTerminal h DebugS V0
+  s <- mkHandleScribe ColorIfTerminal h (permitItem DebugS) V0
   let cleanupHandle = hClose h `finally` (when (dest == TempFile) (removeLink outFile))
   return s { scribeFinalizer = scribeFinalizer s `finally` cleanupHandle}
 
@@ -101,4 +101,7 @@ setup dest = do
 deriving instance NFData ThreadIdText
 
 instance NFData Scribe where
-  rnf (Scribe a b) = (a :: Item ExPayload -> IO ()) `seq` b `seq` ()
+  rnf (Scribe a b p) = (a :: Item ExPayload -> IO ())
+                 `seq`  b
+                 `seq` (p :: Item ExPayload -> IO Bool)
+                 `seq` ()

--- a/katip/examples/example.hs
+++ b/katip/examples/example.hs
@@ -36,7 +36,7 @@ main = do
   -- hot-swap scribes at runtime if you need to. 'closeScribes' is
   -- blocking and flushes all messages out of a scribe and cleans up
   -- resources that were allocated at creation.
-  handleScribe <- mkHandleScribe ColorIfTerminal stdout InfoS V2
+  handleScribe <- mkHandleScribe ColorIfTerminal stdout (permitItem InfoS) V2
   let mkLogEnv = registerScribe "stdout" handleScribe defaultScribeSettings =<< initLogEnv "MyApp" "production"
   bracket mkLogEnv closeScribes $ \le -> do
     let s = MyState M.mempty mempty le

--- a/katip/examples/example_lens.hs
+++ b/katip/examples/example_lens.hs
@@ -51,7 +51,7 @@ main = do
   -- hot-swap scribes at runtime if you need to. 'closeScribes' is
   -- blocking and flushes all messages out of a scribe and cleans up
   -- resources that were allocated at creation.
-  handleScribe <- mkHandleScribe ColorIfTerminal stdout InfoS V2
+  handleScribe <- mkHandleScribe ColorIfTerminal stdout (permitItem InfoS) V2
   let mkLogEnv = registerScribe "stdout" handleScribe defaultScribeSettings =<< initLogEnv "MyApp" "production"
   bracket mkLogEnv closeScribes $ \le -> do
     let s = MyState M.mempty mempty le

--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -1,5 +1,5 @@
 name:                katip
-version:             0.7.0.0
+version:             0.8.0.0
 synopsis:            A structured logging framework.
 description:
   Katip is a structured logging framework. See README.md for more details.

--- a/katip/test/Katip/Tests.hs
+++ b/katip/test/Katip/Tests.hs
@@ -141,6 +141,7 @@ loggingTests = testGroup "logging"
       let scribe = Scribe
             { liPush = \i -> atomically (modifyTVar' items (<> [toObject <$> i]))
             , scribeFinalizer = return ()
+            , scribePermitItem = permitItem DebugS
             }
       le1 <- initLogEnv "tests" "test"
       le2 <- registerScribe "recorder" scribe defaultScribeSettings le1
@@ -154,7 +155,7 @@ trivialScribe :: IO (Scribe, TVar Bool)
 trivialScribe = do
   finalizerCalled <- newTVarIO False
   let finalizer = atomically (writeTVar finalizerCalled True)
-  return (Scribe (const (return ())) finalizer, finalizerCalled)
+  return (Scribe (const (return ())) finalizer (permitItem DebugS), finalizerCalled)
 
 
 -------------------------------------------------------------------------------
@@ -164,7 +165,7 @@ brokenScribe scribeNum = do
   let finalizer = do
         atomically (writeTVar finalizerCalled True)
         throw (ScribeBroken scribeNum)
-  return (Scribe (const (return ())) finalizer, finalizerCalled)
+  return (Scribe (const (return ())) finalizer (permitItem DebugS), finalizerCalled)
 
 
 -------------------------------------------------------------------------------

--- a/katip/test/Katip/Tests/Scribes/Handle.hs
+++ b/katip/test/Katip/Tests/Scribes/Handle.hs
@@ -92,7 +92,7 @@ setup :: IO (FilePath, Handle, IO (), LogEnv)
 setup = do
   tempDir <- getTemporaryDirectory
   (fp, h) <- openTempFile tempDir "katip.log"
-  s <- mkHandleScribe (ColorLog False) h DebugS V3
+  s <- mkHandleScribe (ColorLog False) h (permitItem DebugS) V3
   le <- initLogEnv "katip-test" "test"
   le' <- registerScribe "handle" s defaultScribeSettings le
   return (fp, h, void (closeScribes le'), le')
@@ -111,7 +111,7 @@ setupFile = do
   tempDir <- getTemporaryDirectory
   (fp, h) <- openTempFile tempDir "katip.log"
   hClose h
-  s <- mkFileScribe fp DebugS V3
+  s <- mkFileScribe fp (permitItem DebugS) V3
   le <- initLogEnv "katip-test" "test"
   le' <- registerScribe "handle" s defaultScribeSettings le
   return (fp, void (closeScribes le'), le')

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.14
+resolver: lts-12.22
 packages:
   - katip
   - katip-elasticsearch


### PR DESCRIPTION
Here it is.

Do you think some helper functions for `PermitFunc` should be provided?
Example:
```
-- | Should this item be logged given the user's maximum severity and a list of `Namespace`s?
--   If given `Namespace` is empty, `Namespace` is not checked.
permitSeverity_NS :: Monad m => Severity -> Namespace -> Item a -> m Bool
permitSeverity_NS sev (Namespace ns) Item{..} = return $
     _itemSeverity >= sev
  && (null ns || not (null $ ns `intersect` unNamespace _itemNamespace))
```