### PR TITLE
Export logLoc

### DIFF
--- a/katip/src/Katip.hs
+++ b/katip/src/Katip.hs
@@ -159,6 +159,7 @@ module Katip
     , logF
     , logMsg
     , logT
+    , logLoc
     , logItem
     , logException
     -- ** 'KatipContext': Logging With Context


### PR DESCRIPTION
M version is already exported. I think logLoc should be exported, for symmetry.