### PR TITLE
add all necessary derived instances to Haddock example

### DIFF
--- a/katip/src/Katip.hs
+++ b/katip/src/Katip.hs
@@ -44,7 +44,7 @@
 --
 -- newtype App m a = App {
 --   unApp :: ReaderT Config m a
--- } deriving (Functor, Applicative, Monad) -- more instances as needed
+-- } deriving (Functor, Applicative, Monad, MonadIO, MonadReader Config) -- these are necessary
 --
 --
 -- -- These instances get even easier with lenses!


### PR DESCRIPTION
So I realize that there are examples of how to write instances for a `ReaderT`-style stack in the `examples` directory, but before I read those and figured out what I was doing wrong, I spent about an hour fumbling around trying to fix some type errors, because I assumed the example in the docs was more or less what I needed and I was doing something else wrong (leaving aside extensions and the `lens` scaffolding, assuming one wants to use `lens`). Furthermore, I'm guessing a more experienced Haskell dev would have fewer issues with the errors I ran into, but it seems simple enough to add a few items to the `deriving` line in the docs to avoid confusing those of us who are still learning. I will also add that the examples provided in the `examples` directory are not so minimal, so having a more "barebones" example in the hackage docs still serves a purpose, I believe.

I would also be happy to add a few more bits if you think it's worth it, like loading the `GeneralizedNewtypeDeriving` extension at the top which is assumed, and some basics for deriving `lens`, but I think what you have already mostly strikes the right balance between too much information and just enough. That said, let me know if you want more, or even may be interested in a different approach.

Anyways, I won't be too hurt if you don't want to merge this one line in but figured it may save someone else from the trouble I ran into. Thanks for the library!