### PR TITLE
Implement `logKatipItem` to log the Item

### DIFF
--- a/katip/changelog.md
+++ b/katip/changelog.md
@@ -1,3 +1,8 @@
+0.8.3.0
+=======
+
+* Add `logKatipItem` function and reimplement `logItem` to use it. [vlatkoB](https://github.com/vlatkoB)
+
 0.8.2.0
 =======
 * Add `MonadFail` instances for `base` >= 4.9.0.0 [Koray Al](https://github.com/korayal)

--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -1,5 +1,5 @@
 name:                katip
-version:             0.8.2.0
+version:             0.8.3.0
 synopsis:            A structured logging framework.
 description:
   Katip is a structured logging framework. See README.md for more details.

--- a/katip/src/Katip.hs
+++ b/katip/src/Katip.hs
@@ -161,6 +161,7 @@ module Katip
     , logT
     , logLoc
     , logItem
+    , logKatipItem
     , logException
     -- ** 'KatipContext': Logging With Context
     -- $katipcontextlogging


### PR DESCRIPTION
A new low-level function that logs the Item itself. logItem reimplemented to use this function.
Version raised to 0.8.3.0