### PR TITLE
Try removing MonadIO superclass

### DIFF
--- a/katip/src/Katip/Core.hs
+++ b/katip/src/Katip/Core.hs
@@ -811,12 +811,12 @@ closeScribes le = do
 -- of the log env that are reverted when the supplied monad
 -- completes. 'katipNoLogging', for example, uses this to temporarily
 -- pause log outputs.
-class MonadIO m => Katip m where
+class Katip m where
     getLogEnv :: m LogEnv
     localLogEnv :: (LogEnv -> LogEnv) -> m a -> m a
 
 
-instance Katip m => Katip (ReaderT s m) where
+instance (Katip m, Monad m) => Katip (ReaderT s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = mapReaderT . localLogEnv
 
@@ -828,47 +828,47 @@ instance Katip m => Katip (EitherT s m) where
 #endif
 
 
-instance Katip m => Katip (ExceptT s m) where
+instance (Katip m, Monad m) => Katip (ExceptT s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = mapExceptT . localLogEnv
 
 
-instance Katip m => Katip (MaybeT m) where
+instance (Katip m, Monad m) => Katip (MaybeT m) where
     getLogEnv = lift getLogEnv
     localLogEnv = mapMaybeT . localLogEnv
 
 
-instance Katip m => Katip (StateT s m) where
+instance (Katip m, Monad m) => Katip (StateT s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = mapStateT . localLogEnv
 
 
-instance (Katip m, Monoid w) => Katip (RWST r w s m) where
+instance (Katip m, Monoid w, Monad m) => Katip (RWST r w s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = mapRWST . localLogEnv
 
 
-instance (Katip m, Monoid w) => Katip (Strict.RWST r w s m) where
+instance (Katip m, Monoid w, Monad m) => Katip (Strict.RWST r w s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = Strict.mapRWST . localLogEnv
 
 
-instance Katip m => Katip (Strict.StateT s m) where
+instance (Katip m, Monad m) => Katip (Strict.StateT s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = Strict.mapStateT . localLogEnv
 
 
-instance (Katip m, Monoid s) => Katip (WriterT s m) where
+instance (Katip m, Monoid s, Monad m) => Katip (WriterT s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = mapWriterT . localLogEnv
 
 
-instance (Katip m, Monoid s) => Katip (Strict.WriterT s m) where
+instance (Katip m, Monoid s, Monad m) => Katip (Strict.WriterT s m) where
     getLogEnv = lift getLogEnv
     localLogEnv = Strict.mapWriterT . localLogEnv
 
 
-instance (Katip m) => Katip (ResourceT m) where
+instance (Katip m, Monad m) => Katip (ResourceT m) where
     getLogEnv = lift getLogEnv
     localLogEnv = transResourceT . localLogEnv
 
@@ -937,7 +937,7 @@ katipNoLogging = localLogEnv (\le -> set logEnvScribes mempty le)
 -- | Log with everything, including a source code location. This is
 -- very low level and you typically can use 'logT' in its place.
 logItem
-    :: (A.Applicative m, LogItem a, Katip m)
+    :: (A.Applicative m, LogItem a, Katip m, MonadIO m)
     => a
     -> Namespace
     -> Maybe Loc
@@ -963,7 +963,7 @@ logItem a ns loc sev msg = do
 --   functions use.
 --   It can be useful when implementing centralised logging services.
 logKatipItem
-    :: (A.Applicative m, LogItem a, Katip m)
+    :: (A.Applicative m, LogItem a, Katip m, MonadIO m)
     => Item a
     -> m ()
 logKatipItem item = do
@@ -988,7 +988,7 @@ tryWriteTBQueue q a = do
 -------------------------------------------------------------------------------
 -- | Log with full context, but without any code location.
 logF
-  :: (Applicative m, LogItem a, Katip m)
+  :: (Applicative m, LogItem a, Katip m, MonadIO m)
   => a
   -- ^ Contextual payload for the log
   -> Namespace
@@ -1008,7 +1008,7 @@ logF a ns sev msg = logItem a ns Nothing sev msg
 --
 -- >>>> logException () mempty ErrorS (error "foo")
 logException
-    :: (Katip m, LogItem a, MonadCatch m, Applicative m)
+    :: (Katip m, LogItem a, MonadCatch m, Applicative m, MonadIO m)
     => a                        -- ^ Log context
     -> Namespace                -- ^ Namespace
     -> Severity                 -- ^ Severity
@@ -1023,7 +1023,7 @@ logException a ns sev action = action `catchAny` \e -> f e >> throwM e
 -------------------------------------------------------------------------------
 -- | Log a message without any payload/context or code location.
 logMsg
-    :: (Applicative m, Katip m)
+    :: (Applicative m, Katip m, MonadIO m)
     => Namespace
     -> Severity
     -> LogStr
@@ -1121,9 +1121,9 @@ logT = [| \ a ns sev msg -> logItem a ns (Just $(getLocTH)) sev msg |]
 --
 -- @logLoc obj mempty InfoS "Hello world"@
 #if MIN_VERSION_base(4, 8, 0)
-logLoc :: (Applicative m, LogItem a, Katip m, HasCallStack)
+logLoc :: (Applicative m, LogItem a, Katip m, HasCallStack, MonadIO m)
 #else
-logLoc :: (Applicative m, LogItem a, Katip m)
+logLoc :: (Applicative m, LogItem a, Katip m, MonadIO m)
 #endif
        => a
        -> Namespace

--- a/katip/src/Katip/Monadic.hs
+++ b/katip/src/Katip/Monadic.hs
@@ -151,14 +151,14 @@ class Katip m => KatipContext m where
   -- supplied monad. Used in 'katipAddNamespace'
   localKatipNamespace :: (Namespace -> Namespace) -> m a -> m a
 
-instance (KatipContext m, Katip (IdentityT m)) => KatipContext (IdentityT m) where
+instance (KatipContext m, Katip (IdentityT m), Monad m) => KatipContext (IdentityT m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapIdentityT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = mapIdentityT . localKatipNamespace
 
 
-instance (KatipContext m, Katip (MaybeT m)) => KatipContext (MaybeT m) where
+instance (KatipContext m, Katip (MaybeT m), Monad m) => KatipContext (MaybeT m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapMaybeT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
@@ -166,7 +166,7 @@ instance (KatipContext m, Katip (MaybeT m)) => KatipContext (MaybeT m) where
 
 
 #if !MIN_VERSION_either(4, 5, 0)
-instance (KatipContext m, Katip (EitherT e m)) => KatipContext (EitherT e m) where
+instance (KatipContext m, Katip (EitherT e m), Monad m) => KatipContext (EitherT e m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapEitherT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
@@ -174,77 +174,77 @@ instance (KatipContext m, Katip (EitherT e m)) => KatipContext (EitherT e m) whe
 #endif
 
 
-instance (KatipContext m, Katip (ReaderT r m)) => KatipContext (ReaderT r m) where
+instance (KatipContext m, Katip (ReaderT r m), Monad m) => KatipContext (ReaderT r m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapReaderT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = mapReaderT . localKatipNamespace
 
 
-instance (KatipContext m, Katip (ResourceT m)) => KatipContext (ResourceT m) where
+instance (KatipContext m, Katip (ResourceT m), Monad m) => KatipContext (ResourceT m) where
   getKatipContext = lift getKatipContext
   localKatipContext = transResourceT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = transResourceT . localKatipNamespace
 
 
-instance (KatipContext m, Katip (Strict.StateT s m)) => KatipContext (Strict.StateT s m) where
+instance (KatipContext m, Katip (Strict.StateT s m), Monad m) => KatipContext (Strict.StateT s m) where
   getKatipContext = lift getKatipContext
   localKatipContext = Strict.mapStateT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = Strict.mapStateT . localKatipNamespace
 
 
-instance (KatipContext m, Katip (StateT s m)) => KatipContext (StateT s m) where
+instance (KatipContext m, Katip (StateT s m), Monad m) => KatipContext (StateT s m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapStateT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = mapStateT . localKatipNamespace
 
 
-instance (KatipContext m, Katip (ExceptT e m)) => KatipContext (ExceptT e m) where
+instance (KatipContext m, Katip (ExceptT e m), Monad m) => KatipContext (ExceptT e m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapExceptT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = mapExceptT . localKatipNamespace
 
 
-instance (Monoid w, KatipContext m, Katip (Strict.WriterT w m)) => KatipContext (Strict.WriterT w m) where
+instance (Monoid w, KatipContext m, Katip (Strict.WriterT w m), Monad m) => KatipContext (Strict.WriterT w m) where
   getKatipContext = lift getKatipContext
   localKatipContext = Strict.mapWriterT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = Strict.mapWriterT . localKatipNamespace
 
 
-instance (Monoid w, KatipContext m, Katip (WriterT w m)) => KatipContext (WriterT w m) where
+instance (Monoid w, KatipContext m, Katip (WriterT w m), Monad m) => KatipContext (WriterT w m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapWriterT . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = mapWriterT . localKatipNamespace
 
 
-instance (Monoid w, KatipContext m, Katip (Strict.RWST r w s m)) => KatipContext (Strict.RWST r w s m) where
+instance (Monoid w, KatipContext m, Katip (Strict.RWST r w s m), Monad m) => KatipContext (Strict.RWST r w s m) where
   getKatipContext = lift getKatipContext
   localKatipContext = Strict.mapRWST . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = Strict.mapRWST . localKatipNamespace
 
 
-instance (Monoid w, KatipContext m, Katip (RWST r w s m)) => KatipContext (RWST r w s m) where
+instance (Monoid w, KatipContext m, Katip (RWST r w s m), Monad m) => KatipContext (RWST r w s m) where
   getKatipContext = lift getKatipContext
   localKatipContext = mapRWST . localKatipContext
   getKatipNamespace = lift getKatipNamespace
   localKatipNamespace = mapRWST . localKatipNamespace
 
 
-deriving instance (Monad m, KatipContext m) => KatipContext (KatipT m)
+deriving instance (MonadIO m, KatipContext m) => KatipContext (KatipT m)
 
 -------------------------------------------------------------------------------
 -- | Log with everything, including a source code location. This is
 -- very low level and you typically can use 'logTM' in its
 -- place. Automatically supplies payload and namespace.
 logItemM
-    :: (Applicative m, KatipContext m, HasCallStack)
+    :: (Applicative m, KatipContext m, HasCallStack, MonadIO m)
     => Maybe Loc
     -> Severity
     -> LogStr
@@ -259,7 +259,7 @@ logItemM loc sev msg = do
 -- | Log with full context, but without any code
 -- location. Automatically supplies payload and namespace.
 logFM
-  :: (Applicative m, KatipContext m)
+  :: (Applicative m, KatipContext m, MonadIO m)
   => Severity
   -- ^ Severity of the message
   -> LogStr
@@ -295,7 +295,7 @@ logTM = [| logItemM (Just $(getLocTH)) |]
 -- `logTM` for maximum compatibility.
 --
 -- @logLocM InfoS "Hello world"@
-logLocM :: (Applicative m, KatipContext m, HasCallStack)
+logLocM :: (Applicative m, KatipContext m, HasCallStack, MonadIO m)
         => Severity
         -> LogStr
         -> m ()
@@ -308,7 +308,7 @@ logLocM = logItemM getLoc
 --
 -- >>>> error "foo" `logExceptionM` ErrorS
 logExceptionM
-    :: (KatipContext m, MonadCatch m, Applicative m)
+    :: (KatipContext m, MonadCatch m, Applicative m, MonadIO m)
     => m a                      -- ^ Main action to run
     -> Severity                 -- ^ Severity
     -> m a
@@ -511,7 +511,7 @@ instance MonadIO m => KatipContext (NoLoggingT m) where
 
 -- | Convenience function for when you have to integrate with a third
 -- party API that takes a generic logging function as an argument.
-askLoggerIO :: (Applicative m, KatipContext m) => m (Severity -> LogStr -> IO ())
+askLoggerIO :: (Applicative m, KatipContext m, MonadIO m) => m (Severity -> LogStr -> IO ())
 askLoggerIO = do
   ctx <- getKatipContext
   ns <- getKatipNamespace


### PR DESCRIPTION
This superclass isn't really needed by the Katip class
itself. Basically it prevents you from adding a MonadIO constraint if
you do use logging, but:

1. You get confusing redundant constraint errors when you also have a
MonadIO constraint.
2. It forces you to add MonadIO in some cases where you're not
actually logging.

I had 10 minutes to kill so I thought I'd see how hard it'd be to
remove.

This is in reference to #88

@ozataman LMK if you're okay with this.