### PR TITLE
logLocM doc hint to retain callsite when wrapping

### DIFF
--- a/katip/src/Katip/Monadic.hs
+++ b/katip/src/Katip/Monadic.hs
@@ -287,8 +287,8 @@ logTM = [|logItemM (Just $(getLocTH))|]
 --
 -- Same consideration as `logLoc` applies.
 --
--- By default, ocation will be logged from the module that invokes 'logLocM'.
--- If you want to wrap 'logLocM' in a helper, wrap the entire helper with
+-- By default, location will be logged from the module that invokes 'logLocM'.
+-- If you want to use 'logLocM' in a helper, wrap the entire helper in
 -- 'withFrozenCallStack' to retain the callsite of the helper in the logs.
 --
 -- This function does not require template-haskell. Using GHC <= 7.8 will result


### PR DESCRIPTION
For example, in pseudo-Haskell, this works with nice callsite:

logOnException msg action = withFrozenCallStack $ do
   action `catch` (\e -> logLocM ErrorS (msg <> showLS e) >> throwIO e)