### PR TITLE
Make the test suite work with unordered-containers 0.2.16 and up

### DIFF
--- a/katip/test/Katip/Tests.hs
+++ b/katip/test/Katip/Tests.hs
@@ -79,7 +79,7 @@ logContextsTests =
         let everything = liftPayload (SimpleLogPayload [("foo", AnyLogPayload ("a" :: Text))])
             conservative = liftPayload (ConservativePayload "always" "rarely")
             both = everything <> conservative
-        payloadKeys V2 both @?= SomeKeys ["often_shown", "rarely_shown", "foo"]
+        payloadKeys V2 both @?= SomeKeys somePayloadKeys
         payloadKeys V1 both @?= SomeKeys ["often_shown", "foo"]
     ]
 
@@ -89,6 +89,14 @@ singletonMap = KM.singleton
 #else
 singletonMap :: Text -> v -> HM.HashMap Text v
 singletonMap = HM.singleton
+#endif
+
+#if MIN_VERSION_unordered_containers(0, 2, 16)
+somePayloadKeys :: [Text]
+somePayloadKeys = ["rarely_shown", "often_shown", "foo"]
+#else
+somePayloadKeys :: [Text]
+somePayloadKeys = ["often_shown", "rarely_shown", "foo"]
 #endif
 
 -------------------------------------------------------------------------------

--- a/katip/test/Katip/Tests/Scribes/Handle.hs
+++ b/katip/test/Katip/Tests/Scribes/Handle.hs
@@ -73,6 +73,11 @@ goldenTextPath :: FilePath
 goldenTextPath = "test/Katip/Tests/Scribes/Handle-text-aeson2.golden"
 goldenJsonPath :: FilePath
 goldenJsonPath = "test/Katip/Tests/Scribes/Handle-json-aeson2.golden"
+#elif MIN_VERSION_unordered_containers(0, 2, 16)
+goldenTextPath :: FilePath
+goldenTextPath = "test/Katip/Tests/Scribes/Handle-text-aeson2.golden"
+goldenJsonPath :: FilePath
+goldenJsonPath = "test/Katip/Tests/Scribes/Handle-json-aeson2.golden"
 #else
 goldenTextPath :: FilePath
 goldenTextPath = "test/Katip/Tests/Scribes/Handle-text.golden"


### PR DESCRIPTION
Fixes #134.

This seems to be the same issue with the aeson2 upgrade, though here it also breaks another test due to the order of the keys in the list so applying the flag there as well.