### PR TITLE
Bump Win32 bound to allow up to GHC 9.6

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -87,7 +87,7 @@ library
   if flag(lib-Werror)
     ghc-options: -Werror
   if os(windows)
-    build-depends: Win32 >=2.3 && <2.9
+    build-depends: Win32 >=2.3 && <2.14
     exposed-modules: Katip.Compat
   else
     build-depends: unix >= 2.5 && <2.9


### PR DESCRIPTION
Fixes #144.
