### PR TITLE
Improve logging performance (4x) via inlining

### DIFF
--- a/katip/katip.cabal
+++ b/katip/katip.cabal
@@ -84,7 +84,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:        -Wall
+  ghc-options:        -Wall -O2
   if flag(lib-Werror)
     ghc-options: -Werror
   if os(windows)
@@ -133,7 +133,7 @@ benchmark bench
   main-is: Main.hs
   hs-source-dirs: bench
   default-language:    Haskell2010
-  ghc-options: -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -O2 -Wall -threaded -rtsopts "-with-rtsopts=-N"
   if flag(lib-Werror)
     ghc-options: -Werror
   build-depends:

--- a/katip/src/Katip/Format/Time.hs
+++ b/katip/src/Katip/Format/Time.hs
@@ -41,7 +41,7 @@ formatAsLogTime (UTCTime day time) = toText $
     return (buf, 19)
   where
     toText (arr, len) = Text arr 0 len
-{-# INLINEABLE formatAsLogTime #-}
+{-# INLINE formatAsLogTime #-}
 
 -- | Format 'UTCTime' into a Iso8601 format.
 --
@@ -68,7 +68,7 @@ formatAsIso8601 (UTCTime day time) = toText $
     return (buf, next + 1)
   where
     toText (arr, len) = Text arr 0 len
-{-# INLINEABLE formatAsIso8601 #-}
+{-# INLINE formatAsIso8601 #-}
 
 -- | Writes the @YYYY-MM-DD@ part of timestamp
 writeDay :: TA.MArray s -> Int -> Day -> ST s Int
@@ -115,6 +115,7 @@ writeTimeOfDay doSubSeconds buf off (TOD hh mm ss) =
     T s1 s2 = twoDigits (fromIntegral real)
     (real, frac) = ss `quotRem` pico
     pico = 1000000000000 -- number of picoseconds  in 1 second
+{-# INLINE writeTimeOfDay #-}
 
 writeFracSeconds :: TA.MArray s -> Int -> Int64 -> ST s Int
 writeFracSeconds buf off frac =
@@ -129,6 +130,7 @@ writeFracSeconds buf off frac =
   where
     (mics, mills) = frac `quotRem` micro
     micro = 1000000 -- number of microseconds in 1 second
+{-# INLINE writeFracSeconds #-}
 
 writeDigit6 :: TA.MArray s -> Int -> Int -> ST s ()
 writeDigit6 buf off i =


### PR DESCRIPTION
tl;dr: The inline pragmas total out to ~4x performance improvement in the current benchmark.

Updated the benchmark suite to set up the environment outside of the benchmark code. It heavily pollutes the results for what would--in reality--be a one-time (or infrequent) cost. Additionally, 1000 proved too few writes, so it has been upped to 10000 writes.

Carefully added inline pragmas to many functions, using the benchmark suite and profiling results as a reference. There are a few I am unsure of their impact; it would be nice to have more "real-world" examples to benchmark with and explore more code paths. Others may simply never fire because of how GHC decides to inline (fully saturated functions only). The most impactful functions (found via profiling) were given the most attention.

Notable findings while profiling:
- `brackets` is quite expensive for this benchmark. It took up ~15% of runtime. When inlined, this is hidden (without explicit SCC pragmas), but it is slightly disconcerting how much of the runtime that took up. 
- `scribePermitItem` in `Scribe` is expensive. Unsure what can be done about this. It's a simple enough function (most of the time) that it should be simple to inline, but due to its status as a function in a record, I'm not sure if it *can* inline. It's an indirect function call every time, and it's common enough to be somewhat concerning.
- Compared to other logging libraries, performance seemed *alright*. In terms of raw log output, its ~600x slower than `fast-logger`. Of course, `fast-logger` doesn't have the same feature set and doesn't employ the same "scribe" abstraction. In an old reply on reddit about `katip`'s announcement, it was mentioned that it *might* be possible to use `fast-logger` as a backend for `katip`. I'm fairly sure the changes would be invasive, but the performance improvement could be quite high if that route is taken. *shrug*.