### PR TITLE
Fix build on GHC 9.6 and below

### DIFF
--- a/katip/src/Katip/Core.hs
+++ b/katip/src/Katip/Core.hs
@@ -98,8 +98,9 @@ import           Katip.Compat
 import           System.Posix
 #endif
 
+import           GHC.Conc.Sync                     (labelThread)
 #if MIN_VERSION_base(4, 19, 0)
-import           GHC.Conc.Sync                     (fromThreadId, labelThread)
+import           GHC.Conc.Sync                     (fromThreadId)
 #else
 import           Data.Maybe                        (fromMaybe)
 #endif


### PR DESCRIPTION
PR <https://github.com/Soostone/katip/pull/157> inadvertently conditionalized the import of `labelThread` to `base` 4.19 and above, which breaks the build on earlier versions.

This unconditionalizes the import.